### PR TITLE
Create netlify.toml 🚨

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200


### PR DESCRIPTION
## Fixed Page Refresh 404 Error

When navigating to a route like `/about` or any route and refreshing the page, the site initially encountered a **404 Page Not Found** error. After making the necessary adjustments, the issue was resolved. Below are the before and after screenshots illustrating the change.

### Before:

![404 Error](https://github.com/user-attachments/assets/17190a24-5fe0-42ec-b041-0d1adcaf2787)

---

### After:

![Fixed Refresh](https://github.com/user-attachments/assets/75ec1bfd-9127-4f9b-9112-622c4eedfcef)

---

With the new configuration, the page now correctly stays on the route even after refreshing, without encountering a 404 error.
